### PR TITLE
Add FinQA training scripts

### DIFF
--- a/train_finqa_grpo.sh
+++ b/train_finqa_grpo.sh
@@ -1,0 +1,83 @@
+export CUDA_VISIBLE_DEVICES=0
+export DATA_DIR='data/finqa_search'
+
+WAND_PROJECT='Search-R1'
+
+# export BASE_MODEL='meta-llama/Llama-3.2-3B'
+# export EXPERIMENT_NAME=finqa-search-r1-grpo-llama3.2-3b-em
+# export BASE_MODEL='meta-llama/Llama-3.2-3B-Instruct'
+# export EXPERIMENT_NAME=finqa-search-r1-grpo-llama3.2-3b-it-em
+# export BASE_MODEL='meta-llama/Llama-3.1-8B'
+# export EXPERIMENT_NAME=finqa-search-r1-grpo-llama3.1-8b-em
+# export BASE_MODEL='meta-llama/Llama-3.1-8B-Instruct'
+# export EXPERIMENT_NAME=finqa-search-r1-grpo-llama3.1-8b-it-em
+
+export BASE_MODEL='Qwen/Qwen2.5-3B'
+export EXPERIMENT_NAME=finqa-search-r1-grpo-qwen2.5-3b-em
+# export BASE_MODEL='Qwen/Qwen2.5-3B-Instruct'
+# export EXPERIMENT_NAME=finqa-search-r1-grpo-qwen2.5-3b-it-em
+# export BASE_MODEL='Qwen/Qwen2.5-7B'
+# export EXPERIMENT_NAME=finqa-search-r1-grpo-qwen2.5-7b-em
+# export BASE_MODEL='Qwen/Qwen2.5-7B-Instruct'
+# export EXPERIMENT_NAME=finqa-search-r1-grpo-qwen2.5-7b-it-em
+
+# set -x
+export VLLM_ATTENTION_BACKEND=XFORMERS # vllm + qwen2-7b with flash_attn has some issues
+
+# max_prompt_length = (config['training']['max_start_length'] + config['training']['max_response_length'] * (config['training']['max_turns'] - 1) + config['training']['max_obs_length'] * config['training']['max_turns'])
+
+PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo \
+    data.train_files=$DATA_DIR/train.parquet \
+    data.val_files=$DATA_DIR/test.parquet \
+    data.train_data_num=null \
+    data.val_data_num=null \
+    data.train_batch_size=64 \
+    data.val_batch_size=32 \
+    data.max_prompt_length=4096 \
+    data.max_response_length=500 \
+    data.max_start_length=2048 \
+    data.max_obs_length=500 \
+    data.shuffle_train_dataloader=True \
+    algorithm.adv_estimator=grpo \
+    actor_rollout_ref.model.path=$BASE_MODEL \
+    actor_rollout_ref.model.enable_gradient_checkpointing=true \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.285 \
+    actor_rollout_ref.actor.use_kl_loss=true \
+    actor_rollout_ref.actor.ppo_mini_batch_size=32 \
+    actor_rollout_ref.actor.ppo_micro_batch_size=8 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=false \
+    actor_rollout_ref.actor.fsdp_config.grad_offload=false \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=false \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size=8 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=False \
+    actor_rollout_ref.actor.kl_loss_coef=0.001 \
+    actor_rollout_ref.actor.kl_loss_type=low_var_kl \
+    algorithm.no_think_rl=false \
+    actor_rollout_ref.rollout.n_agent=1 \
+    actor_rollout_ref.rollout.temperature=1 \
+    actor_rollout_ref.actor.state_masking=true \
+    trainer.logger=['wandb'] \
+    +trainer.val_only=false \
+    +trainer.val_before_train=true \
+    trainer.default_hdfs_dir=null \
+    trainer.n_gpus_per_node=1 \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=50 \
+    trainer.project_name=$WAND_PROJECT \
+    trainer.experiment_name=$EXPERIMENT_NAME \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=1005 \
+    trainer.default_hdfs_dir=null \
+    trainer.default_local_dir=verl_checkpoints/$EXPERIMENT_NAME \
+    max_turns=2 \
+    retriever.url=null \
+    retriever.topk=3 \
+    generation.use_local_indexer=true 
+    2>&1 | tee $EXPERIMENT_NAME.log

--- a/train_finqa_ppo.sh
+++ b/train_finqa_ppo.sh
@@ -1,0 +1,91 @@
+export CUDA_VISIBLE_DEVICES=0
+export DATA_DIR='data/finqa_search'
+
+WAND_PROJECT='Search-R1'
+
+export BASE_MODEL='meta-llama/Llama-3.2-3B'
+export EXPERIMENT_NAME=finqa-search-r1-ppo-llama3.2-3b-em
+# export BASE_MODEL='meta-llama/Llama-3.2-3B-Instruct'
+# export EXPERIMENT_NAME=finqa-search-r1-ppo-llama3.2-3b-it-em
+# export BASE_MODEL='meta-llama/Llama-3.1-8B'
+# export EXPERIMENT_NAME=finqa-search-r1-ppo-llama3.1-8b-em
+# export BASE_MODEL='meta-llama/Llama-3.1-8B-Instruct'
+# export EXPERIMENT_NAME=finqa-search-r1-ppo-llama3.1-8b-it-em
+
+# export BASE_MODEL='Qwen/Qwen2.5-3B'
+# export EXPERIMENT_NAME=finqa-search-r1-ppo-qwen2.5-3b-em
+# export BASE_MODEL='Qwen/Qwen2.5-3B-Instruct'
+# export EXPERIMENT_NAME=finqa-search-r1-ppo-qwen2.5-3b-it-em
+# export BASE_MODEL='Qwen/Qwen2.5-7B'
+# export EXPERIMENT_NAME=finqa-search-r1-ppo-qwen2.5-7b-em
+# export BASE_MODEL='Qwen/Qwen2.5-7B-Instruct'
+# export EXPERIMENT_NAME=finqa-search-r1-ppo-qwen2.5-7b-it-em
+
+# set -x
+export VLLM_ATTENTION_BACKEND=XFORMERS # vllm + qwen2-7b with flash_attn has some issues
+
+# max_prompt_length = (config['training']['max_start_length'] + config['training']['max_response_length'] * (config['training']['max_turns'] - 1) + config['training']['max_obs_length'] * config['training']['max_turns'])
+
+PYTHONUNBUFFERED=1 python3 -m verl.trainer.main_ppo \
+    data.train_files=$DATA_DIR/train.parquet \
+    data.val_files=$DATA_DIR/test.parquet \
+    data.train_data_num=null \
+    data.val_data_num=null \
+    data.train_batch_size=64 \
+    data.val_batch_size=32 \
+    data.max_prompt_length=4096 \
+    data.max_response_length=500 \
+    data.max_start_length=2048 \
+    data.max_obs_length=500 \
+    data.shuffle_train_dataloader=True \
+    algorithm.adv_estimator=gae \
+    actor_rollout_ref.model.path=$BASE_MODEL \
+    actor_rollout_ref.actor.optim.lr=1e-6 \
+    actor_rollout_ref.model.enable_gradient_checkpointing=true \
+    actor_rollout_ref.model.use_remove_padding=True \
+    actor_rollout_ref.actor.optim.lr_warmup_steps_ratio=0.285 \
+    actor_rollout_ref.actor.ppo_mini_batch_size=32 \
+    actor_rollout_ref.actor.ppo_micro_batch_size=8 \
+    actor_rollout_ref.actor.fsdp_config.param_offload=false \
+    actor_rollout_ref.actor.fsdp_config.grad_offload=false \
+    actor_rollout_ref.actor.fsdp_config.optimizer_offload=false \
+    actor_rollout_ref.rollout.log_prob_micro_batch_size=8 \
+    actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+    actor_rollout_ref.rollout.name=vllm \
+    actor_rollout_ref.rollout.gpu_memory_utilization=0.6 \
+    actor_rollout_ref.ref.log_prob_micro_batch_size=8 \
+    actor_rollout_ref.ref.fsdp_config.param_offload=False \
+    actor_rollout_ref.rollout.n_agent=1 \
+    actor_rollout_ref.rollout.temperature=1 \
+    actor_rollout_ref.actor.state_masking=true \
+    critic.optim.lr=1e-5 \
+    critic.model.use_remove_padding=True \
+    critic.optim.lr_warmup_steps_ratio=0.015 \
+    critic.model.path=$BASE_MODEL \
+    critic.model.enable_gradient_checkpointing=true \
+    critic.ppo_micro_batch_size=8 \
+    critic.model.fsdp_config.param_offload=false \
+    critic.model.fsdp_config.grad_offload=false \
+    critic.model.fsdp_config.optimizer_offload=false \
+    algorithm.kl_ctrl.kl_coef=0.001 \
+    algorithm.no_think_rl=false \
+    trainer.critic_warmup=0 \
+    trainer.logger=['wandb'] \
+    +trainer.val_only=false \
+    +trainer.val_before_train=true \
+    trainer.default_hdfs_dir=null \
+    trainer.n_gpus_per_node=1 \
+    trainer.nnodes=1 \
+    trainer.save_freq=100 \
+    trainer.test_freq=50 \
+    trainer.project_name=$WAND_PROJECT \
+    trainer.experiment_name=$EXPERIMENT_NAME \
+    trainer.total_epochs=15 \
+    trainer.total_training_steps=1005 \
+    trainer.default_hdfs_dir=null \
+    trainer.default_local_dir=verl_checkpoints/$EXPERIMENT_NAME \
+    max_turns=2 \
+    retriever.url=null \
+    retriever.topk=3 \
+    generation.use_local_indexer=true 
+    2>&1 | tee $EXPERIMENT_NAME.log


### PR DESCRIPTION
## Summary
- add FinQA PPO and GRPO scripts
- configure `DATA_DIR` for `finqa_search`
- disable external retriever and enable local indexer
- adjust settings for 1 A100 GPU

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685304c28c5c832fb4ddd8dff8f33829